### PR TITLE
select(null) -> deselectAll()

### DIFF
--- a/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
+++ b/vaadin-crud-flow/src/main/java/com/vaadin/flow/component/crud/Crud.java
@@ -457,7 +457,7 @@ public class Crud<E> extends Component implements HasSize, HasTheme {
 
     private void clearActiveItem() {
         this.gridActiveItem = null;
-        grid.select(null);
+        grid.deselectAll();
     }
 
     /**


### PR DESCRIPTION
See SelectionModel JavaDoc (Grid#select uses SelectionModel#select):

    /**
     * Selects the given item. Depending on the implementation, may cause other
     * items to be deselected. If the item is already selected, does nothing.
     *
     * @param item
     *            the item to select, not null
     */
    void select(T item);